### PR TITLE
Support passing command line arguments: <source> <destination>

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # ignore diff files
 *.diff
+node_modules

--- a/README.md
+++ b/README.md
@@ -12,16 +12,33 @@ problem.
 
 ## Usage
 
-Install [Node.js].
+Install [Node.js]
 
+1. Create a backup of all of the files on your USB drive
 1. Delete all the files from your USB drive.
-2. Change `sourcePath` and `destPath` to appropriate folders for your computer.
-3. Run `node app.js` and wait as the files are copied over.
+1. Run `npm install` to install the required node packages
+1. Run `./app.js <sourcePath> <destinationPath>` with the appropriate folders and wait as the files are copied over.
+
+
+```
+$ ./app.js --help
+
+  Usage: app <source> <destination>
+
+  Sort files and folders alphabetically on a USB drive.
+
+  Options:
+
+    -h, --help     output usage information
+    -V, --version  output the version number
+```
+
+This package can also be installed globally via `npm install -g` and run with the command `usb-file-sorter`.
 
 ## Future Features
 
+* Submit to npm
 * GUI
-* Pass command-line arguments instead of hard-coding constants
 * Do the re-ordering without having to delete everything and copying (I'm not
   sure if this is even possible, but would be worth looking into)
 * Visual feedback as the files are copied over

--- a/app.js
+++ b/app.js
@@ -1,6 +1,31 @@
-const fs = require('fs-plus');
+#!/usr/bin/env node
+'use strict';
 
-const sourcePath = '/media/oakmac/storage/Car USB/';
-const destPath = '/media/oakmac/C848-2D72/';
+var program = require('commander');
+var fs = require('fs-plus');
+var packageInfo = require('./package.json');
 
-fs.copySync(sourcePath, destPath);
+var source, destination;
+
+program
+  .version(packageInfo.version)
+  .description(packageInfo.description)
+  .usage('<source> <destination>')
+  .arguments('<source> <destination>')
+  .action(function(src, dest){
+    source = src;
+    destination = dest;
+  })
+  .parse(process.argv);
+
+// Show help text if no arguments are given
+if (!program.args.length) {
+    program.help();
+}
+
+if (!fs.existsSync(source)) {
+   console.error('The source does not exist');
+   process.exit(1);
+}
+
+fs.copySync(source, destination);

--- a/package.json
+++ b/package.json
@@ -1,10 +1,22 @@
 {
-  "author": "Chris Oakman <chris@oakmac.com> (http://chrisoakman.com/)",
   "name": "usb-file-sorter",
-  "description": "Sort files and folders alphabetically on a USB drive.",
-  "license": "ISC",
   "version": "0.0.1",
+  "description": "Sort files and folders alphabetically on a USB drive.",
+  "author": "Chris Oakman <chris@oakmac.com> (http://chrisoakman.com/)",
+  "license": "ISC",
+  "main": "app.js",
+  "bin": {
+    "usb-file-sorter": "./app.js"
+  },
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/oakmac/usb-file-sorter"
+  },
   "dependencies": {
+    "commander": "^2.9.0",
     "fs-plus": "2.8.1"
+  },
+  "engines": {
+    "node": ">= 0.10"
   }
 }


### PR DESCRIPTION
- Support for command line args.
- Added commander package
- Updated README.md usage

Now you can use `./app.js <source> <destination>`
